### PR TITLE
RTEMS 6/7 Support for slac-3.2.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -5,6 +5,10 @@ Release Notes for iocStats
 # Releases
 
 ## iocStats-R3-2-0:
+R3.2.0-1.0.0: 2025-09-23 Jeremy Lorelli
+    Add support for RTEMS 7 (cherry-picked)
+    Fix issue with iocClusters.db (cherry-picked)
+
 
 **NOTE** Please note that as of 3-2-0, there is a pre-commit (https://pre-commit.com/) workflow that
 includes

--- a/devIocStats/os/RTEMS/devIocStatsOSD.h
+++ b/devIocStats/os/RTEMS/devIocStatsOSD.h
@@ -72,6 +72,7 @@
 
 #undef malloc
 #undef free
+#undef random
 
 #if (__RTEMS_MAJOR__ > 4) || (__RTEMS_MAJOR__ == 4 && __RTEMS_MINOR__ > 7)
 #define RTEMS_PROTECTED_HEAP

--- a/devIocStats/os/RTEMS/osdCpuUtilization.c
+++ b/devIocStats/os/RTEMS/osdCpuUtilization.c
@@ -27,7 +27,6 @@ int devIocStatsInitCpuUtilization(loadInfo *pval) {
   return 0;
 }
 
-/* FIXME: This relies on the device support calling it after CpuUsage */
 int devIocStatsGetCpuUtilization(loadInfo *pval) {
   pval->iocLoad = pval->cpuLoad;
   return 0;

--- a/devIocStats/os/RTEMS/osdFdUsage.c
+++ b/devIocStats/os/RTEMS/osdFdUsage.c
@@ -38,9 +38,16 @@
 
 #include <devIocStats.h>
 
+#if __RTEMS_MAJOR__ >= 6
+#include <rtems/libio_.h>
+#endif /* _RTEMS_MAJOR__ >= 6 */
+
 int devIocStatsInitFDUsage(void) { return 0; }
 
 int devIocStatsGetFDUsage(fdInfo *pval) {
+#if __RTEMS_MAJOR__ >= 6
+  pval->used = rtems_libio_count_open_iops();
+#else
   int i, tot;
 
   for (tot = 0, i = 0; i < rtems_libio_number_iops; i++) {
@@ -48,6 +55,7 @@ int devIocStatsGetFDUsage(fdInfo *pval) {
       tot++;
   }
   pval->used = tot;
+#endif /* _RTEMS_MAJOR__ >= 6 */
   pval->max = rtems_libio_number_iops;
   return 0;
 }

--- a/devIocStats/os/RTEMS/osdSuspTasks.c
+++ b/devIocStats/os/RTEMS/osdSuspTasks.c
@@ -43,6 +43,7 @@
 int devIocStatsInitSuspTasks(void) { return 0; }
 
 int devIocStatsGetSuspTasks(int *pval) {
+#if __RTEMS_MAJOR__ < 6
   Objects_Control *o;
   Objects_Id id = OBJECTS_ID_INITIAL_INDEX;
   Objects_Id nid;
@@ -59,4 +60,7 @@ int devIocStatsGetSuspTasks(int *pval) {
   }
   *pval = n;
   return 0;
+#else  /* __RTEMS_MAJOR__ < 6 */
+  return -1;
+#endif /* __RTEMS_MAJOR__ < 6 */
 }

--- a/devIocStats/os/RTEMS/osdWorkspaceUsage.c
+++ b/devIocStats/os/RTEMS/osdWorkspaceUsage.c
@@ -31,6 +31,10 @@ int devIocStatsInitWorkspaceUsage(void) { return 0; }
 
 int devIocStatsGetWorkspaceUsage(memInfo *pval) {
   Heap_Information_block info;
+#if __RTEMS_MAJOR__ >= 6
+  malloc_info(&info);
+  pval->numBytesTotal = info.Stats.size;
+#else /* __RTEMS_MAJOR__ >= 6 */
 #ifdef RTEMS_PROTECTED_HEAP
   _Protected_heap_Get_information(&_Workspace_Area, &info);
 #else  /* RTEMS_PROTECTED_HEAP */
@@ -45,6 +49,7 @@ int devIocStatsGetWorkspaceUsage(memInfo *pval) {
 #else
   pval->numBytesTotal = _Configuration_Table->work_space_size;
 #endif
+#endif /* _RTEMS_MAJOR__ >= 6 */
   pval->numBytesFree = info.Free.total;
   pval->numBytesAlloc = info.Used.total;
   return 0;

--- a/iocAdmin/Db/iocCluster.template
+++ b/iocAdmin/Db/iocCluster.template
@@ -1,36 +1,28 @@
 record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_0") {
     field(DESC, "$(TYPE) Size")
     field(DTYP, "IOC stats clusts")
-    field(INP, "@clust_
-
-    info $(P) $(S) 0")
+    field(INP, "@clust_info $(P) $(S) 0")
     field(FLNK, "$(IOCNAME):CLUST_$(P)_$(S)_1")
 }
 
 record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_1") {
     field(DESC, "$(TYPE) Clusters")
     field(DTYP, "IOC stats clusts")
-    field(INP, "@clust_
-
-    info $(P) $(S) 1")
+    field(INP, "@clust_info $(P) $(S) 1")
     field(FLNK, "$(IOCNAME):CLUST_$(P)_$(S)_2")
 }
 
 record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_2") {
     field(DESC, "$(TYPE) Free")
     field(DTYP, "IOC stats clusts")
-    field(INP, "@clust_
-
-    info $(P) $(S) 2")
+    field(INP, "@clust_info $(P) $(S) 2")
     field(FLNK, "$(IOCNAME):CLUST_$(P)_$(S)_3")
 }
 
 record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_3") {
     field(DESC, "$(TYPE) Usage")
     field(DTYP, "IOC stats clusts")
-    field(INP, "@clust_
-
-    info $(P) $(S) 3")
+    field(INP, "@clust_info $(P) $(S) 3")
     field(FLNK, "$(IOCNAME):$(TYPE)_CLUST_AVAIL_$(S)")
 }
 


### PR DESCRIPTION
Still builds on RTEMS 4.X

Contains the following:
* Cherry-picked commit from Chris Johns adding RTEMS 6/7 support with libbsd and legacy networking
    * Build fix for this commit
* Fix for bad dbformat in iocClustered.template. Cherry-picked from latest iocAdmin master branch (this commit is not in a release yet).